### PR TITLE
fix: original release date lost to a reissue sharing the ISRC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "musicalist",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "musicalist",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "electron"
   ],
   "main": "src/index.js",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "electron-squirrel-startup": "^1.0.1"

--- a/src/api/musicbrainz.js
+++ b/src/api/musicbrainz.js
@@ -163,18 +163,14 @@ function escapeQuery(value) {
 }
 
 //! Resolution
-// Preferred route: the ISRC from Deezer is an exact identifier, so it maps to
-// the right recording without any fuzzy matching.
-async function recordingIdFromIsrc(isrc) {
-    const body = await request(`${API_BASE}/isrc/${encodeURIComponent(isrc)}?fmt=json`)
-    const recordings = body && Array.isArray(body.recordings) ? body.recordings : []
-    return recordings.length ? recordings[0].id : null
-}
-
 // A well known song matches hundreds of recordings that all score 100, because
 // every compilation and live album counts as its own recording. Taking the first
 // hit lands on an arbitrary repackaging with no genres attached, so rank the top
 // scorers and keep the one that looks like the original studio release.
+//
+// The ISRC endpoint returns neither scores nor releases, which this degrades to
+// cleanly: every entry ties at score 0 with no release group to inspect, so the
+// release date alone decides.
 function pickRecording(recordings) {
     if (!Array.isArray(recordings) || recordings.length === 0) return null
 
@@ -193,6 +189,18 @@ function pickRecording(recordings) {
 
     scored.sort((a, b) => a.repackaged - b.repackaged || a.date.localeCompare(b.date))
     return scored[0].entry.id
+}
+
+// Preferred route: the ISRC from Deezer is an exact identifier, so it needs no
+// fuzzy matching to find the song. It does not identify one recording though.
+// Labels reissue a track under its original ISRC, so a remaster and the pressing
+// it was cut from share one code, and MusicBrainz returns them in no particular
+// order. Taking the first entry therefore dated "Smells Like Teen Spirit" to the
+// 2021 remaster, which also carries none of the genres the 1991 recording has,
+// so the same ranking the search path uses picks between them.
+async function recordingIdFromIsrc(isrc) {
+    const body = await request(`${API_BASE}/isrc/${encodeURIComponent(isrc)}?fmt=json`)
+    return pickRecording(body && body.recordings)
 }
 
 // Fallback for tracks with no ISRC, or an ISRC MusicBrainz has never seen.

--- a/test/musicbrainz.test.js
+++ b/test/musicbrainz.test.js
@@ -292,6 +292,57 @@ test('resolves through the ISRC and then loads the recording', async (t) => {
     assert.match(fetch.calls[1].url, /inc=genres\+tags\+releases\+release-groups/)
 })
 
+// A reissue keeps the original ISRC, so one code can name several recordings.
+// The remaster is a real hit, not a bad match, so only the date separates them.
+test('prefers the original when one ISRC covers a remaster too', async (t) => {
+    const fetch = stubFetch((url) => {
+        if (url.includes('/isrc/'))
+            return response({
+                recordings: [
+                    {
+                        id: 'remaster',
+                        title: 'Smells Like Teen Spirit (remastered 2021)',
+                        'first-release-date': '2021-11-10'
+                    },
+                    {
+                        id: 'original',
+                        title: 'Smells Like Teen Spirit',
+                        'first-release-date': '1991-09-10'
+                    }
+                ]
+            })
+        return response(recording({ id: 'original', 'first-release-date': '1991-09-10' }))
+    })
+    t.after(fetch.restore)
+
+    const result = await enrich({ isrc: 'USGF19942501', title: 'Smells Like Teen Spirit' })
+
+    assert.equal(result.mbRecordingId, 'original')
+    assert.equal(result.originalReleaseDate, '1991-09-10')
+    assert.match(fetch.calls[1].url, /\/recording\/original\?/)
+})
+
+// The ISRC payload has no scores and no releases, so the ranking has to survive
+// both being absent rather than reading them off undefined.
+test('ranks ISRC hits that carry no score or releases', () => {
+    assert.equal(
+        pickRecording([
+            { id: 'late', 'first-release-date': '2021-11-10' },
+            { id: 'early', 'first-release-date': '1991-09-10' }
+        ]),
+        'early'
+    )
+})
+
+// An undated entry must not win by default, but it is still better than nothing.
+test('keeps an undated ISRC hit behind a dated one', () => {
+    assert.equal(
+        pickRecording([{ id: 'undated' }, { id: 'dated', 'first-release-date': '1991' }]),
+        'dated'
+    )
+    assert.equal(pickRecording([{ id: 'only' }]), 'only')
+})
+
 test('falls back to a text search when the ISRC is unknown', async (t) => {
     const fetch = stubFetch((url) => {
         if (url.includes('/isrc/')) return response({ recordings: [] })


### PR DESCRIPTION
## The bug

`recordingIdFromIsrc` took `recordings[0]` from the MusicBrainz ISRC endpoint. An ISRC does not identify a single recording: labels reissue a track under its original code, so a remaster and the pressing it was cut from share one, and MusicBrainz returns them in no particular order.

`USGF19942501` (Smells Like Teen Spirit) returns two recordings:

```
[ "Smells Like Teen Spirit (remastered 2021)"  2021-11-10   <- recordings[0]
  "Smells Like Teen Spirit"                     1991-09-10 ]
```

The ranking in `pickRecording`, which exists precisely to avoid landing on a repackaging, was never reached because the ISRC path short-circuits ahead of it.

## Impact was wider than the date

Pulling both recordings individually:

| | date | genres | tags |
|---|---|---|---|
| remaster (was picked) | 2021-11-10 | 0 | 0 |
| original | 1991-09-10 | 5 | 8 |

So this also silently emptied genres and tags on affected tracks. `canonicalReleaseGroup` could not recover the date either: the remaster's release group is a 2021 Single with no secondary types, so nothing downstream reads as a repackaging.

Because MusicBrainz does not guarantee the order, this was luck of the draw rather than a stable wrong answer.

## The fix

Route the ISRC hits through the `pickRecording` ranking that already existed for the search path, rather than adding a second one. It degrades cleanly on the ISRC payload: no `score` means every entry ties at 0, no `releases` means nothing reads as repackaged, so the release date alone decides.

`pickRecording` moved above the ISRC lookup so both resolution paths read in order.

Considered and rejected: requesting `inc=releases` on the ISRC call to give the repackaging check something to work with. Larger payload for no gain, since the dates already separate these cleanly, and it risks demoting an original whose only surviving releases are compilations.

## Verification

Live, through the real `enrich`:

```
originalReleaseDate: 1991-09-10   (was 2021-11-10)
genres: grunge, alternative rock, rock, pop, punk rock   (was empty)
```

99/99 tests pass, four of them new: the shared-ISRC case, ranking with no scores or releases, undated hits, and the single-hit regression. Prettier clean. Packaged build reports 1.1.2 and the fix was confirmed present inside `app.asar`.