### PR TITLE
feat: add danceability and mood from AcousticBrainz

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Musicalist takes a list of songs and gives you back structured metadata for every one of them: artists, album, release date, genres, length, and more. It then summarises the whole list, so you can see what a collection actually looks like rather than reading it song by song.
 
-Data comes from two places. [Deezer's public API](https://developers.deezer.com/api) identifies each track and supplies the catalogue facts, including tempo. [MusicBrainz](https://musicbrainz.org) supplies genres, the original release date, and the release typing. Both are open, so there is nothing to sign up for and nothing to configure: install Musicalist, paste your songs, and go. The app is built with [Electron](https://www.electronjs.org).
+Data comes from three places. [Deezer's public API](https://developers.deezer.com/api) identifies each track and supplies the catalogue facts, including tempo. [MusicBrainz](https://musicbrainz.org) supplies genres, the original release date, and the release typing. [AcousticBrainz](https://acousticbrainz.org) adds danceability and mood where its archive reaches. All three are open, so there is nothing to sign up for and nothing to configure: install Musicalist, paste your songs, and go. The app is built with [Electron](https://www.electronjs.org).
 
 This project follows [Semantic Versioning](https://semver.org). See the [latest release](https://github.com/KotvicCodes/musicalist/releases/latest) for the current version.
 
@@ -67,16 +67,23 @@ Reissue drift is worth explaining. Deezer serves whichever release of a song it 
 | Original release date                                                   | MusicBrainz          |
 | Release type and secondary types (Live, Compilation, Soundtrack, Remix) | MusicBrainz          |
 | Recording ID                                                            | MusicBrainz          |
+| Danceability                                                            | AcousticBrainz       |
+| Mood: happy, sad, aggressive, relaxed, party, acoustic, electronic      | AcousticBrainz       |
+| Instrumental                                                            | AcousticBrainz       |
 
 ## Limitations
 
 **BPM is not universal.** Deezer publishes a tempo for most tracks but not all. Where it has none, the field is left blank rather than filled with a zero, and the summary says how many songs it had to skip so an average is never mistaken for the whole list.
 
-**No energy, danceability or mood yet.** Spotify [deprecated](https://developer.spotify.com/documentation/web-api/reference/get-audio-features) its audio-features endpoints in November 2024 and restricted them to apps registered before then, and the commercial services charge for access. AcousticBrainz stopped accepting new submissions in 2022, but that only ended collection: the archive it gathered is still served, it is free, and it is keyed by the same recording ID Musicalist already looks up. Danceability and mood are therefore reachable for the songs it happens to hold, and support is being built. Energy is not: nothing free publishes it, so Musicalist would have to invent the number.
+**Mood stops at 2022.** Danceability and mood come from AcousticBrainz, which stopped accepting new submissions in 2022. The archive it gathered is still served and still free, but nothing has been added since, so a song released after the cutoff almost never has an analysis. Older catalogue is covered well. Where there is nothing, the fields are left blank rather than filled with a zero, which is a real score here, and the summary says how many songs it could analyse.
+
+**Mood is a guess, not a measurement.** Each figure is a classifier's probability, not a fact about the song, and the models were trained on small sets. Treat them as a rough sort rather than a verdict. Musicalist deliberately ignores the archive's genre and gender classifiers, which are unreliable enough to file "Smells Like Teen Spirit" as trance; genres come from MusicBrainz instead.
+
+**No energy.** Spotify [deprecated](https://developer.spotify.com/documentation/web-api/reference/get-audio-features) its audio-features endpoints in November 2024 and restricted them to apps registered before then, the commercial services charge for access, and AcousticBrainz never published an energy classifier. Musicalist could only invent the number, so it does not report one.
 
 **Deezer genres are coarse.** They are attached to the album rather than the track, and tend toward broad buckets like Rock or Pop. That is why MusicBrainz carries the genre load here; the Deezer genres are shown as a bonus.
 
-**Speed is set by MusicBrainz.** MusicBrainz allows one request per second per application and blocks addresses that exceed it, so Musicalist spaces its calls deliberately. Deezer is far more generous, at 50 requests every 5 seconds, so it is never the bottleneck. Expect roughly two to three seconds per song, meaning a hundred-song list takes a few minutes.
+**Speed is set by MusicBrainz.** MusicBrainz allows one request per second per application and blocks addresses that exceed it, so Musicalist spaces its calls deliberately. Deezer is far more generous, at 50 requests every 5 seconds, so it is never the bottleneck. AcousticBrainz adds a request per song, but it lands inside a gap MusicBrainz was already making the run wait out, so it costs almost nothing. Expect roughly two to three seconds per song, meaning a hundred-song list takes a few minutes.
 
 **Matching is best-effort.** Songs are matched to MusicBrainz by ISRC where Deezer provides one, which is exact. Where it does not, Musicalist falls back to a text search and picks the most original-looking recording, which is usually right but not guaranteed. Deezer's own search takes the top hit for your query, so an ambiguous query can land on a live version or a remaster; adding the artist name makes it far more reliable.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Reissue drift is worth explaining. Deezer serves whichever release of a song it 
 
 **BPM is not universal.** Deezer publishes a tempo for most tracks but not all. Where it has none, the field is left blank rather than filled with a zero, and the summary says how many songs it had to skip so an average is never mistaken for the whole list.
 
-**No energy, danceability or mood.** Only tempo is freely available. Spotify [deprecated](https://developer.spotify.com/documentation/web-api/reference/get-audio-features) its audio-features endpoints in November 2024 and restricted them to apps registered before then, AcousticBrainz stopped collecting in 2022, and the remaining services charge for access. There is no mood analysis in Musicalist for now.
+**No energy, danceability or mood yet.** Spotify [deprecated](https://developer.spotify.com/documentation/web-api/reference/get-audio-features) its audio-features endpoints in November 2024 and restricted them to apps registered before then, and the commercial services charge for access. AcousticBrainz stopped accepting new submissions in 2022, but that only ended collection: the archive it gathered is still served, it is free, and it is keyed by the same recording ID Musicalist already looks up. Danceability and mood are therefore reachable for the songs it happens to hold, and support is being built. Energy is not: nothing free publishes it, so Musicalist would have to invent the number.
 
 **Deezer genres are coarse.** They are attached to the album rather than the track, and tend toward broad buckets like Rock or Pop. That is why MusicBrainz carries the genre load here; the Deezer genres are shown as a bonus.
 

--- a/musicbrainz.js
+++ b/musicbrainz.js
@@ -1,0 +1,239 @@
+// SPDX-FileCopyrightText: 2025-2026 Kotvič
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Constants
+const API_BASE = 'https://musicbrainz.org/ws/2'
+
+// MusicBrainz asks for a descriptive User-Agent and blocks IPs that exceed one
+// request per second. The extra 100 ms is deliberate headroom, not a guess.
+// The version is read rather than written out so it cannot drift out of date
+// and start misreporting which build is calling.
+const { version } = require('../../package.json')
+const USER_AGENT = `Musicalist/${version} ( https://github.com/KotvicCodes/Musicalist )`
+const MIN_GAP_MS = 1100
+
+// A recording lookup with these includes returns genres, tags and the parent
+// release groups in a single response, so no follow-up call is needed.
+const RECORDING_INC = 'genres+tags+releases+release-groups'
+
+// How many genres and tags to keep once sorted by community vote count.
+const MAX_GENRES = 8
+const MAX_TAGS = 8
+
+//! Helpers
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+//! Throttle
+// Every request funnels through one promise chain, so calls are serialised and
+// spaced regardless of how many songs are in flight.
+let queue = Promise.resolve()
+let lastRequestAt = 0
+
+function throttled(task) {
+    const run = queue.then(async () => {
+        const wait = lastRequestAt + MIN_GAP_MS - Date.now()
+        if (wait > 0) await sleep(wait)
+        lastRequestAt = Date.now()
+        return task()
+    })
+
+    // Keep the chain alive even when one call rejects, otherwise a single
+    // failure would poison every later lookup.
+    queue = run.then(
+        () => undefined,
+        () => undefined
+    )
+    return run
+}
+
+//! Request
+// MusicBrainz failures are never fatal here: a song without genres is still a
+// useful row, so callers get null instead of an exception.
+async function request(url) {
+    return throttled(async () => {
+        try {
+            const response = await fetch(url, {
+                headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' }
+            })
+            if (!response.ok) return null
+            return await response.json()
+        } catch {
+            return null
+        }
+    })
+}
+
+//! Sorting
+// Genres and tags both carry a community vote `count`; the most agreed-upon
+// ones first, alphabetical as a tiebreak so output is stable.
+function byCountThenName(a, b) {
+    const diff = (b.count || 0) - (a.count || 0)
+    return diff !== 0 ? diff : String(a.name).localeCompare(String(b.name))
+}
+
+function rankNamed(list, limit) {
+    if (!Array.isArray(list)) return []
+    return list
+        .filter((entry) => entry && entry.name)
+        .slice()
+        .sort(byCountThenName)
+        .slice(0, limit)
+        .map((entry) => ({ name: entry.name, count: entry.count || 0 }))
+}
+
+//! Release Groups
+// A popular song can hang off two dozen releases: reissues, compilations,
+// live albums, soundtracks. Secondary types mark all of those as repackagings,
+// so an original release always beats one even if it is dated later, and among
+// equals the earliest wins. Album breaks a date tie against the single, since
+// it is the more informative answer for a song that came out as both.
+function isRepackaging(group) {
+    return Array.isArray(group['secondary-types']) && group['secondary-types'].length > 0
+}
+
+function rankGroup(group) {
+    return [
+        isRepackaging(group) ? 1 : 0,
+        group['first-release-date'] || '9999',
+        group['primary-type'] === 'Album' ? 0 : 1
+    ]
+}
+
+function canonicalReleaseGroup(releases) {
+    if (!Array.isArray(releases)) return null
+
+    const groups = releases.map((release) => release && release['release-group']).filter(Boolean)
+    if (groups.length === 0) return null
+
+    return groups.reduce((best, group) => {
+        const [aRepack, aDate, aType] = rankGroup(group)
+        const [bRepack, bDate, bType] = rankGroup(best)
+        if (aRepack !== bRepack) return aRepack < bRepack ? group : best
+        if (aDate !== bDate) return aDate < bDate ? group : best
+        return aType < bType ? group : best
+    })
+}
+
+//! Extraction
+// Turn a recording lookup into the MusicBrainz half of a song row.
+function extractRecording(recording) {
+    const empty = {
+        mbRecordingId: null,
+        originalReleaseDate: null,
+        releaseType: null,
+        releaseSecondaryTypes: [],
+        genreWeights: [],
+        wikiGenres: [],
+        tags: []
+    }
+    if (!recording || !recording.id) return empty
+
+    const group = canonicalReleaseGroup(recording.releases)
+
+    // Recording level genres are the most specific, but they are often empty
+    // while the release group carries good data, so fall back to it.
+    let genres = rankNamed(recording.genres, MAX_GENRES)
+    if (genres.length === 0 && group) {
+        genres = rankNamed(group.genres, MAX_GENRES)
+    }
+
+    let tags = rankNamed(recording.tags, MAX_TAGS)
+    if (tags.length === 0 && group) {
+        tags = rankNamed(group.tags, MAX_TAGS)
+    }
+
+    return {
+        mbRecordingId: recording.id,
+        originalReleaseDate:
+            recording['first-release-date'] || (group ? group['first-release-date'] : null) || null,
+        releaseType: group ? group['primary-type'] || null : null,
+        releaseSecondaryTypes:
+            group && Array.isArray(group['secondary-types']) ? group['secondary-types'] : [],
+        genreWeights: genres,
+        wikiGenres: genres.map((genre) => genre.name),
+        tags: tags.map((tag) => tag.name)
+    }
+}
+
+//! Lucene Escaping
+// Titles routinely contain quotes, colons and brackets, all of which are Lucene
+// syntax in a MusicBrainz search query.
+function escapeQuery(value) {
+    return String(value).replace(/([+\-!(){}[\]^"~*?:\\/]|&&|\|\|)/g, '\\$1')
+}
+
+//! Resolution
+// A well known song matches hundreds of recordings that all score 100, because
+// every compilation and live album counts as its own recording. Taking the first
+// hit lands on an arbitrary repackaging with no genres attached, so rank the top
+// scorers and keep the one that looks like the original studio release.
+//
+// The ISRC endpoint returns neither scores nor releases, which this degrades to
+// cleanly: every entry ties at score 0 with no release group to inspect, so the
+// release date alone decides.
+function pickRecording(recordings) {
+    if (!Array.isArray(recordings) || recordings.length === 0) return null
+
+    const best = Math.max(...recordings.map((entry) => entry.score || 0))
+    const tied = recordings.filter((entry) => (entry.score || 0) === best)
+
+    const scored = tied.map((entry) => {
+        const groups = (entry.releases || []).map((release) => release['release-group']).filter(Boolean)
+        return {
+            entry,
+            // an original pressing exists among this recording's releases
+            repackaged: groups.length && groups.every(isRepackaging) ? 1 : 0,
+            date: entry['first-release-date'] || '9999'
+        }
+    })
+
+    scored.sort((a, b) => a.repackaged - b.repackaged || a.date.localeCompare(b.date))
+    return scored[0].entry.id
+}
+
+// Preferred route: the ISRC from Deezer is an exact identifier, so it needs no
+// fuzzy matching to find the song. It does not identify one recording though.
+// Labels reissue a track under its original ISRC, so a remaster and the pressing
+// it was cut from share one code, and MusicBrainz returns them in no particular
+// order. Taking the first entry therefore dated "Smells Like Teen Spirit" to the
+// 2021 remaster, which also carries none of the genres the 1991 recording has,
+// so the same ranking the search path uses picks between them.
+async function recordingIdFromIsrc(isrc) {
+    const body = await request(`${API_BASE}/isrc/${encodeURIComponent(isrc)}?fmt=json`)
+    return pickRecording(body && body.recordings)
+}
+
+// Fallback for tracks with no ISRC, or an ISRC MusicBrainz has never seen.
+async function recordingIdFromSearch(title, artist) {
+    if (!title) return null
+
+    const parts = [`recording:"${escapeQuery(title)}"`]
+    if (artist) parts.push(`artist:"${escapeQuery(artist)}"`)
+
+    const params = new URLSearchParams({ fmt: 'json', limit: '25', query: parts.join(' AND ') })
+    const body = await request(`${API_BASE}/recording?${params}`)
+    return pickRecording(body && body.recordings)
+}
+
+//! Public Lookup
+// Two throttled requests per song: resolve the recording, then fetch it with
+// everything included.
+async function enrich({ isrc, title, artist }) {
+    let id = null
+    if (isrc) id = await recordingIdFromIsrc(isrc)
+    if (!id) id = await recordingIdFromSearch(title, artist)
+    if (!id) return extractRecording(null)
+
+    const recording = await request(`${API_BASE}/recording/${id}?fmt=json&inc=${RECORDING_INC}`)
+    return extractRecording(recording)
+}
+
+//! Export
+module.exports = {
+    enrich,
+    extractRecording,
+    canonicalReleaseGroup,
+    pickRecording,
+    escapeQuery,
+    rankNamed
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "musicalist",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "musicalist",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "electron-squirrel-startup": "^1.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "metadata",
     "deezer",
     "musicbrainz",
+    "acousticbrainz",
+    "mood",
     "electron"
   ],
   "main": "src/index.js",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "electron-squirrel-startup": "^1.0.1"

--- a/src/analysis.js
+++ b/src/analysis.js
@@ -9,6 +9,21 @@
     const TOP_GENRES = 10
     const TOP_ARTISTS = 5
 
+    // Repeated rather than imported from the AcousticBrainz client, because the
+    // renderer loads this file as a plain script and has no require(). A test
+    // asserts the two lists stay identical.
+    const MOOD_FIELDS = [
+        'danceability',
+        'moodHappy',
+        'moodSad',
+        'moodAggressive',
+        'moodRelaxed',
+        'moodParty',
+        'moodAcoustic',
+        'moodElectronic',
+        'instrumental'
+    ]
+
     //! Helpers
 
     // Deezer serves whichever reissue it happens to carry, so its release date is
@@ -121,6 +136,25 @@
             ? Math.round(tempos.reduce((sum, value) => sum + value, 0) / tempos.length)
             : null
 
+        //* Mood
+        // AcousticBrainz stopped taking submissions in 2022, so it holds well
+        // under half of a typical list. Each mean covers only the songs it
+        // actually has, and audioMissing is reported for the same reason
+        // bpmMissing is: an average drawn from a third of the list must never
+        // read as a verdict on all of it.
+        const moods = {}
+        for (const field of MOOD_FIELDS) {
+            const values = found.map((row) => row[field]).filter((value) => typeof value === 'number')
+            moods[field] = values.length
+                ? Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 1000) /
+                  1000
+                : null
+        }
+
+        // One field standing in for the row as a whole: the archive returns
+        // every classifier together or none at all.
+        const analysed = found.filter((row) => typeof row.danceability === 'number')
+
         //* Explicit
         const rated = found.filter((row) => typeof row.explicit === 'boolean')
         const explicitCount = rated.filter((row) => row.explicit).length
@@ -156,6 +190,9 @@
             // the tenths carry no meaning to someone scanning a summary.
             medianBpm: tempos.length ? Math.round(median(tempos)) : null,
             bpmMissing: found.length - tempos.length,
+            moods,
+            audioAnalysed: analysed.length,
+            audioMissing: found.length - analysed.length,
             explicit: {
                 count: explicitCount,
                 ratio: rated.length ? explicitCount / rated.length : 0
@@ -180,7 +217,7 @@
     //! Export
     // Loaded two ways: as a CommonJS module by the tests and the main
     // process, and as a plain script by the renderer, which has no require().
-    const api = { summarise, formatDuration, effectiveYear }
+    const api = { summarise, formatDuration, effectiveYear, MOOD_FIELDS }
 
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = api

--- a/src/api/acousticbrainz.js
+++ b/src/api/acousticbrainz.js
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2025-2026 Kotvič
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Constants
+const API_BASE = 'https://acousticbrainz.org/api/v1'
+
+const { version } = require('../../package.json')
+const USER_AGENT = `Musicalist/${version} ( https://github.com/KotvicCodes/Musicalist )`
+
+// AcousticBrainz publishes no rate limit, but it is a volunteer archive and
+// this only ever runs behind the MusicBrainz lookup, which already spaces
+// itself a second apart. The gap below is a floor that in practice never
+// binds; it exists so a future caller cannot accidentally hammer the service.
+const MIN_GAP_MS = 250
+
+// Every classifier is a two-class model, and `all` carries the probability of
+// each class by name. Reading the positive class straight out of `all` is what
+// keeps the sign honest: the sibling `probability` field is confidence in
+// whichever label won, so a track that is 88% *not* happy reports 0.879 there
+// and would read as overwhelmingly happy if taken at face value.
+const FEATURES = {
+    danceability: ['danceability', 'danceable'],
+    moodHappy: ['mood_happy', 'happy'],
+    moodSad: ['mood_sad', 'sad'],
+    moodAggressive: ['mood_aggressive', 'aggressive'],
+    moodRelaxed: ['mood_relaxed', 'relaxed'],
+    moodParty: ['mood_party', 'party'],
+    moodAcoustic: ['mood_acoustic', 'acoustic'],
+    moodElectronic: ['mood_electronic', 'electronic'],
+    instrumental: ['voice_instrumental', 'instrumental']
+}
+
+// The genre and gender classifiers are deliberately not read. They are trained
+// on small sets and are visibly unreliable: the archive files "Smells Like Teen
+// Spirit" as trance. MusicBrainz already supplies real genres with community
+// vote weights, so a worse second opinion would only muddy them.
+
+//! Helpers
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// Three decimals is well past the point where these models are meaningful and
+// keeps the exported spreadsheet readable.
+function round(value) {
+    return Math.round(value * 1000) / 1000
+}
+
+//! Throttle
+let queue = Promise.resolve()
+let lastRequestAt = 0
+
+function throttled(task) {
+    const run = queue.then(async () => {
+        const wait = lastRequestAt + MIN_GAP_MS - Date.now()
+        if (wait > 0) await sleep(wait)
+        lastRequestAt = Date.now()
+        return task()
+    })
+
+    queue = run.then(
+        () => undefined,
+        () => undefined
+    )
+    return run
+}
+
+//! Request
+// Same contract as the MusicBrainz client: a song without mood data is still a
+// useful row, so every failure resolves to null instead of throwing. A 404 is
+// the ordinary case here rather than an error, since the archive only holds
+// what volunteers submitted before it closed to new data.
+async function request(url) {
+    return throttled(async () => {
+        try {
+            const response = await fetch(url, {
+                headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' }
+            })
+            if (!response.ok) return null
+            return await response.json()
+        } catch {
+            return null
+        }
+    })
+}
+
+//! Extraction
+// Absent data has to look exactly like Deezer's missing BPM: null, never zero.
+// Zero is a real value for every one of these fields, so filling a gap with it
+// would quietly drag any average toward the floor.
+function emptyFeatures() {
+    const empty = {}
+    for (const key of Object.keys(FEATURES)) empty[key] = null
+    return empty
+}
+
+function extractFeatures(body) {
+    const highlevel = body && body.highlevel
+    if (!highlevel) return emptyFeatures()
+
+    const features = emptyFeatures()
+    for (const [field, [classifier, positive]] of Object.entries(FEATURES)) {
+        const entry = highlevel[classifier]
+        if (!entry) continue
+
+        const all = entry.all
+        if (all && typeof all[positive] === 'number') {
+            features[field] = round(all[positive])
+            continue
+        }
+
+        // Older submissions occasionally omit `all`. The label still says which
+        // class won, so the positive probability is recoverable from it.
+        if (typeof entry.probability === 'number' && typeof entry.value === 'string') {
+            features[field] = round(entry.value === positive ? entry.probability : 1 - entry.probability)
+        }
+    }
+
+    return features
+}
+
+//! Public Lookup
+// Keyed by the MusicBrainz recording ID, which the enrichment step has already
+// resolved, so this costs one request and no extra matching. Picking the wrong
+// recording upstream is not a soft failure here: a remaster and its original
+// are separate IDs, and the archive almost always holds only the original.
+async function features(mbRecordingId) {
+    if (!mbRecordingId) return emptyFeatures()
+
+    const body = await request(`${API_BASE}/${encodeURIComponent(mbRecordingId)}/high-level`)
+    return extractFeatures(body)
+}
+
+//! Export
+module.exports = { features, extractFeatures, emptyFeatures, FEATURES }

--- a/src/api/lookup.js
+++ b/src/api/lookup.js
@@ -4,6 +4,7 @@
 //! Import
 const { createClient } = require('./deezer.js')
 const musicbrainz = require('./musicbrainz.js')
+const acousticbrainz = require('./acousticbrainz.js')
 
 //! Blank Row
 // A song Deezer cannot find still gets a row, so the output lines up with the
@@ -35,13 +36,15 @@ function blankRow(query) {
         releaseSecondaryTypes: [],
         genreWeights: [],
         tags: [],
-        mbRecordingId: null
+        mbRecordingId: null,
+        ...acousticbrainz.emptyFeatures()
     }
 }
 
 //! Single Song
 // Deezer identifies the track and carries the catalogue facts; MusicBrainz
-// supplies the genres and the original release date.
+// supplies the genres and the original release date; AcousticBrainz adds mood
+// and danceability for the recordings it happens to hold.
 async function lookupSong(deezer, query) {
     const track = await deezer.searchTrack(query)
     if (!track) return blankRow(query)
@@ -54,11 +57,19 @@ async function lookupSong(deezer, query) {
         artist: primaryArtist?.name
     })
 
+    // Has to follow the enrichment rather than run alongside it, because the
+    // recording id is the key. The extra round trip is close to free in wall
+    // clock terms: MusicBrainz spaces its own calls a second apart from the
+    // last one it made, so this lands inside a gap the run was already waiting
+    // out. It returns nulls rather than throwing, so it cannot fail a row.
+    const audio = await acousticbrainz.features(enrichment.mbRecordingId)
+
     return {
         ...blankRow(query),
         ...track,
         found: true,
-        ...enrichment
+        ...enrichment,
+        ...audio
     }
 }
 

--- a/src/export.js
+++ b/src/export.js
@@ -21,6 +21,17 @@ const COLUMNS = [
     ['releaseSecondaryTypes', (row) => row.releaseSecondaryTypes],
     ['durationMs', (row) => row.durationMs],
     ['bpm', (row) => row.bpm],
+    // Probabilities from 0 to 1, blank where AcousticBrainz has no analysis for
+    // the recording. Blank rather than 0, which is a real score here.
+    ['danceability', (row) => row.danceability],
+    ['moodHappy', (row) => row.moodHappy],
+    ['moodSad', (row) => row.moodSad],
+    ['moodAggressive', (row) => row.moodAggressive],
+    ['moodRelaxed', (row) => row.moodRelaxed],
+    ['moodParty', (row) => row.moodParty],
+    ['moodAcoustic', (row) => row.moodAcoustic],
+    ['moodElectronic', (row) => row.moodElectronic],
+    ['instrumental', (row) => row.instrumental],
     ['explicit', (row) => row.explicit],
     ['trackNumber', (row) => row.trackNumber],
     ['discNumber', (row) => row.discNumber],
@@ -72,7 +83,7 @@ function toJson(rows, summary) {
     return JSON.stringify(
         {
             exportedAt: new Date().toISOString(),
-            source: 'Musicalist (Deezer API + MusicBrainz)',
+            source: 'Musicalist (Deezer API + MusicBrainz + AcousticBrainz)',
             summary: summary || null,
             songs: Array.isArray(rows) ? rows : []
         },

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -4,6 +4,22 @@
 //! Constants
 const REPO_URL = 'https://github.com/KotvicCodes/musicalist#readme'
 
+// The classifiers worth naming on screen, in the order they read best. A trait
+// is listed only once it wins its own two-class model, so 0.5 is the threshold
+// rather than an arbitrary cut.
+const MOOD_LABELS = {
+    moodAggressive: 'aggressive',
+    moodParty: 'party',
+    moodHappy: 'happy',
+    moodSad: 'sad',
+    moodRelaxed: 'relaxed',
+    moodAcoustic: 'acoustic',
+    moodElectronic: 'electronic',
+    instrumental: 'instrumental'
+}
+
+const MOOD_THRESHOLD = 0.5
+
 const { summarise, formatDuration } = window.MusicalistAnalysis
 const { escapeHtml, textToArray } = window.MusicalistText
 
@@ -164,6 +180,28 @@ function renderSummary() {
         )
     }
 
+    // Both cells carry the analysed count, because the archive covers well under
+    // half a typical list and an average over a third of it should say so.
+    if (summary.moods.danceability !== null) {
+        const coverage = summary.audioMissing
+            ? `${summary.audioAnalysed} of ${summary.audioAnalysed + summary.audioMissing} analysed`
+            : `all ${summary.audioAnalysed} analysed`
+
+        cell('Danceability', `${Math.round(summary.moods.danceability * 100)}%`, coverage)
+
+        const strongest = Object.keys(MOOD_LABELS)
+            .filter((field) => summary.moods[field] !== null)
+            .sort((a, b) => summary.moods[b] - summary.moods[a])[0]
+
+        if (strongest && summary.moods[strongest] >= MOOD_THRESHOLD) {
+            cell(
+                'Mood',
+                MOOD_LABELS[strongest],
+                `${Math.round(summary.moods[strongest] * 100)}% average`
+            )
+        }
+    }
+
     summaryStatsQ.innerHTML = cells.join('')
 }
 
@@ -188,6 +226,19 @@ function renderSong(song) {
             ? `${text(song.originalReleaseDate)} <span class="song__aside">(Deezer: ${text(deezerDate)})</span>`
             : text(deezerDate || song.originalReleaseDate)
 
+    // Every trait that won its own model, strongest first, with danceability as
+    // a number since it is the one people compare between songs. A song the
+    // archive never analysed falls through to the em dash like any other gap.
+    const traits = Object.entries(MOOD_LABELS)
+        .filter(([field]) => typeof song[field] === 'number' && song[field] >= MOOD_THRESHOLD)
+        .sort((a, b) => song[b[0]] - song[a[0]])
+        .map(([, label]) => label)
+
+    const moodLine =
+        typeof song.danceability === 'number'
+            ? [...traits, `${Math.round(song.danceability * 100)}% danceable`].join(', ')
+            : null
+
     const albumLine = [
         song.album,
         song.releaseType || song.albumType,
@@ -204,6 +255,7 @@ function renderSong(song) {
                <dt>Released</dt><dd>${released}</dd>
                <dt>Length</dt><dd>${text(formatDuration(song.durationMs))}</dd>
                <dt>BPM</dt><dd>${text(song.bpm === null || song.bpm === undefined ? null : Math.round(song.bpm))}</dd>
+               <dt>Mood</dt><dd>${text(moodLine)}</dd>
                <dt>Genres</dt><dd>${list(song.wikiGenres)}</dd>
                <dt>Deezer genres</dt><dd>${list(song.deezerGenres)}</dd>
                <dt>Tags</dt><dd>${list(song.tags)}</dd>

--- a/test/acousticbrainz.test.js
+++ b/test/acousticbrainz.test.js
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2025-2026 Kotvič
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { features, extractFeatures, emptyFeatures } = require('../src/api/acousticbrainz.js')
+const { response, stubFetch } = require('./helpers.js')
+
+//! Fixtures
+// A two-class classifier as the archive actually returns it: `all` holds both
+// classes by name, `probability` repeats whichever one won.
+const classifier = (positive, negative, positiveP) => ({
+    all: { [positive]: positiveP, [negative]: 1 - positiveP },
+    probability: positiveP >= 0.5 ? positiveP : 1 - positiveP,
+    value: positiveP >= 0.5 ? positive : negative
+})
+
+const highlevel = (overrides = {}) => ({
+    highlevel: {
+        danceability: classifier('danceable', 'not_danceable', 0.47),
+        mood_happy: classifier('happy', 'not_happy', 0.121),
+        mood_sad: classifier('sad', 'not_sad', 0.057),
+        mood_aggressive: classifier('aggressive', 'not_aggressive', 0.949),
+        mood_relaxed: classifier('relaxed', 'not_relaxed', 0.018),
+        mood_party: classifier('party', 'not_party', 0.737),
+        mood_acoustic: classifier('acoustic', 'not_acoustic', 0.008),
+        mood_electronic: classifier('electronic', 'not_electronic', 0.51),
+        voice_instrumental: classifier('instrumental', 'voice', 0.019),
+        ...overrides
+    }
+})
+
+//! Extraction
+test('reads the positive class rather than the winning label', () => {
+    // The regression this guards: mood_happy below is 87.9% confident the song
+    // is NOT happy. Taking `probability` at face value would report it as one
+    // of the happiest tracks in the list.
+    const result = extractFeatures(highlevel())
+
+    assert.equal(result.moodHappy, 0.121)
+    assert.equal(result.moodAggressive, 0.949)
+    assert.equal(result.danceability, 0.47)
+    assert.equal(result.instrumental, 0.019)
+})
+
+test('recovers the positive class when a submission omits all', () => {
+    const result = extractFeatures({
+        highlevel: {
+            mood_happy: { probability: 0.879, value: 'not_happy' },
+            mood_party: { probability: 0.737, value: 'party' }
+        }
+    })
+
+    assert.equal(result.moodHappy, 0.121)
+    assert.equal(result.moodParty, 0.737)
+})
+
+test('leaves unknown features null rather than zero', () => {
+    // Zero is a real value for every one of these, so a gap filled with it
+    // would drag an average down instead of being skipped.
+    const result = extractFeatures({ highlevel: { danceability: classifier('danceable', 'x', 0.9) } })
+
+    assert.equal(result.danceability, 0.9)
+    assert.equal(result.moodHappy, null)
+    assert.equal(result.moodSad, null)
+})
+
+test('returns an all-null shape for missing or malformed bodies', () => {
+    assert.deepEqual(extractFeatures(null), emptyFeatures())
+    assert.deepEqual(extractFeatures({}), emptyFeatures())
+    assert.deepEqual(extractFeatures({ highlevel: {} }), emptyFeatures())
+    assert.equal(
+        Object.values(emptyFeatures()).every((value) => value === null),
+        true
+    )
+})
+
+test('ignores the unreliable genre and gender classifiers', () => {
+    const result = extractFeatures(
+        highlevel({
+            genre_dortmund: classifier('electronic', 'rock', 0.97),
+            gender: classifier('male', 'female', 0.94)
+        })
+    )
+
+    assert.equal('genre_dortmund' in result, false)
+    assert.equal('gender' in result, false)
+    assert.deepEqual(Object.keys(result).sort(), Object.keys(emptyFeatures()).sort())
+})
+
+//! Lookup
+test('looks the recording up by its MusicBrainz id', async (t) => {
+    const fetch = stubFetch(() => response(highlevel()))
+    t.after(fetch.restore)
+
+    const result = await features('rec-1')
+
+    assert.match(fetch.calls[0].url, /\/rec-1\/high-level$/)
+    assert.equal(result.moodHappy, 0.121)
+})
+
+test('treats a missing recording as no data, not an error', async (t) => {
+    // The archive closed to new submissions in 2022, so a 404 is the ordinary
+    // case for anything it never gathered.
+    const fetch = stubFetch(() => response({ message: 'Not found' }, { status: 404 }))
+    t.after(fetch.restore)
+
+    assert.deepEqual(await features('rec-missing'), emptyFeatures())
+})
+
+test('survives a dead connection without throwing', async (t) => {
+    const fetch = stubFetch(() => {
+        throw new Error('socket hang up')
+    })
+    t.after(fetch.restore)
+
+    assert.deepEqual(await features('rec-1'), emptyFeatures())
+})
+
+test('skips the request entirely when there is no recording id', async (t) => {
+    const fetch = stubFetch(() => response(highlevel()))
+    t.after(fetch.restore)
+
+    assert.deepEqual(await features(null), emptyFeatures())
+    assert.equal(fetch.calls.length, 0)
+})

--- a/test/analysis.test.js
+++ b/test/analysis.test.js
@@ -4,7 +4,9 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
 
-const { summarise, formatDuration, effectiveYear } = require('../src/analysis.js')
+const { summarise, formatDuration, effectiveYear, MOOD_FIELDS } = require('../src/analysis.js')
+const { FEATURES } = require('../src/api/acousticbrainz.js')
+const { blankRow } = require('../src/api/lookup.js')
 const { songRow } = require('./helpers.js')
 
 //! Counts
@@ -223,4 +225,42 @@ test('counts distinct artists and the most frequent one', () => {
 
     assert.equal(summary.artists.distinct, 3)
     assert.deepEqual(summary.artists.top[0], { name: 'Queen', count: 2 })
+})
+
+//! Mood
+test('averages each mood over only the songs the archive covers', () => {
+    const summary = summarise([
+        songRow({ danceability: 0.8, moodHappy: 0.9 }),
+        songRow({ danceability: 0.4, moodHappy: 0.3 }),
+        songRow({ danceability: null, moodHappy: null })
+    ])
+
+    assert.equal(summary.moods.danceability, 0.6)
+    assert.equal(summary.moods.moodHappy, 0.6)
+    assert.equal(summary.audioAnalysed, 2)
+    assert.equal(summary.audioMissing, 1)
+})
+
+test('reports null rather than zero when nothing was analysed', () => {
+    // Zero would read as "every song scored zero danceability" instead of
+    // "no song had data", which is the same trap bpmMissing exists to avoid.
+    const summary = summarise([songRow({ danceability: null, moodHappy: null })])
+
+    assert.equal(summary.moods.danceability, null)
+    assert.equal(summary.moods.moodHappy, null)
+    assert.equal(summary.audioAnalysed, 0)
+    assert.equal(summary.audioMissing, 1)
+})
+
+test('does not count songs Deezer never found as missing analysis', () => {
+    const summary = summarise([songRow({ danceability: 0.5 }), blankRow('Nonsense')])
+
+    assert.equal(summary.audioAnalysed, 1)
+    assert.equal(summary.audioMissing, 0)
+})
+
+test('keeps the mood field list in step with the AcousticBrainz client', () => {
+    // analysis.js cannot require the client, because the renderer loads it as a
+    // plain script. This is what stops the two lists drifting apart.
+    assert.deepEqual(MOOD_FIELDS.slice().sort(), Object.keys(FEATURES).sort())
 })

--- a/test/export.test.js
+++ b/test/export.test.js
@@ -104,3 +104,36 @@ test('keeps every field of the song record', () => {
     assert.deepEqual(parsed.songs[0].genreWeights[0], { name: 'rock', count: 13 })
     assert.equal(parsed.summary, null)
 })
+
+//! Audio Features
+test('exports each mood as its own column', () => {
+    const csv = toCsv([songRow({ danceability: 0.82, moodAggressive: 0.95, moodHappy: 0.12 })])
+    const [header, row] = csv.replace(/^﻿/, '').trim().split('\r\n')
+
+    const columns = header.split(',')
+    const values = row.split(',')
+    const read = (name) => values[columns.indexOf(name)]
+
+    assert.equal(read('danceability'), '0.82')
+    assert.equal(read('moodAggressive'), '0.95')
+    assert.equal(read('moodHappy'), '0.12')
+})
+
+test('leaves an unanalysed song blank rather than zero', () => {
+    // 0 is a real danceability score, so writing it for missing data would be
+    // indistinguishable from a song the archive scored at the floor.
+    const csv = toCsv([songRow({ danceability: null, moodHappy: null })])
+    const [header, row] = csv.replace(/^﻿/, '').trim().split('\r\n')
+
+    const columns = header.split(',')
+    const values = row.split(',')
+
+    assert.equal(values[columns.indexOf('danceability')], '')
+    assert.equal(values[columns.indexOf('moodHappy')], '')
+})
+
+test('names AcousticBrainz as a source in the JSON export', () => {
+    const parsed = JSON.parse(toJson([songRow()], null))
+
+    assert.match(parsed.source, /AcousticBrainz/)
+})

--- a/test/lookup.test.js
+++ b/test/lookup.test.js
@@ -10,8 +10,21 @@ const { response, stubFetch, deezerHit, deezerTrack, deezerAlbum } = require('./
 //! Helpers
 // One stub covering both services, so a run can be driven end to end. Songs are
 // keyed by the query they are found under.
-function stubEverything({ tracks = {}, mbDown = false } = {}) {
+function stubEverything({ tracks = {}, mbDown = false, audio = null } = {}) {
     return stubFetch((url) => {
+        if (url.includes('acousticbrainz.org')) {
+            if (!audio) return response({ message: 'Not found' }, { status: 404 })
+            return response({
+                highlevel: {
+                    danceability: {
+                        all: { danceable: audio.danceable, not_danceable: 1 - audio.danceable },
+                        probability: audio.danceable,
+                        value: 'danceable'
+                    }
+                }
+            })
+        }
+
         if (url.includes('api.deezer.com')) {
             if (url.includes('/search')) {
                 const query = new URL(url).searchParams.get('q')
@@ -156,4 +169,55 @@ test('a dead connection stops the run instead of failing every song', async (t) 
     )
 
     assert.equal(seen.length, 0)
+})
+
+//! Audio Features
+test('merges AcousticBrainz mood into the row', async (t) => {
+    const fetch = stubEverything({ tracks: { Bohemian: deezerTrack() }, audio: { danceable: 0.82 } })
+    t.after(fetch.restore)
+
+    const [row] = await lookupSongs(['Bohemian'])
+
+    assert.equal(row.danceability, 0.82)
+    assert.ok(
+        fetch.calls.some((call) => call.url.includes('acousticbrainz.org/api/v1/rec-1/high-level'))
+    )
+})
+
+test('a song the archive has never seen keeps every other field', async (t) => {
+    // Coverage is partial by design, so a miss has to look like Deezer's
+    // missing BPM: blank, with the rest of the row intact.
+    const fetch = stubEverything({ tracks: { Bohemian: deezerTrack() } })
+    t.after(fetch.restore)
+
+    const [row] = await lookupSongs(['Bohemian'])
+
+    assert.equal(row.danceability, null)
+    assert.equal(row.moodHappy, null)
+    assert.equal(row.found, true)
+    assert.equal(row.title, 'Bohemian Rhapsody')
+    assert.equal(row.originalReleaseDate, '1975-11-21')
+})
+
+test('does not call the archive when MusicBrainz found no recording', async (t) => {
+    const fetch = stubEverything({ tracks: { Bohemian: deezerTrack() }, mbDown: true })
+    t.after(fetch.restore)
+
+    const [row] = await lookupSongs(['Bohemian'])
+
+    assert.equal(row.found, true)
+    assert.equal(row.danceability, null)
+    assert.equal(
+        fetch.calls.some((call) => call.url.includes('acousticbrainz.org')),
+        false
+    )
+})
+
+test('a blank row carries the audio fields too, so every row is the same shape', () => {
+    const row = blankRow('Missing')
+
+    assert.equal('danceability' in row, true)
+    assert.equal('moodHappy' in row, true)
+    assert.equal('instrumental' in row, true)
+    assert.equal(row.danceability, null)
 })


### PR DESCRIPTION
Re-targets #17, which merged into `fix/isrc-picks-remaster` instead of `main`. That branch had already been merged via #16, so the feature never reached `main`. Same six commits, nothing rewritten.

## What this adds

Danceability and seven mood classifiers per song, from [AcousticBrainz](https://acousticbrainz.org), keyed by the MusicBrainz recording ID the app already looks up. No auth, no signup, no new identifier resolution.

The README had recorded these fields as impossible:

> AcousticBrainz stopped collecting in 2022, and the remaining services charge for access.

That conflates the archive ending *collection* with the archive being gone. It is still served and still free. Two of the three deferred fields were reachable the whole time.

## Coverage

Measured over 20 songs through the real pipeline: 14 analysed. Every miss was released after 2022, which is when the archive closed to submissions:

```
YES  Paranoid Android   1997      no  Anti-Hero   2022
YES  One More Time      2000      no  Flowers     2023
YES  Bad Romance        2009      no  vampire     2023
YES  Blinding Lights    2019      no  Espresso    2024
```

A date cutoff rather than a flat sampling gap, so the README says that instead of quoting a percentage.

## Depends on the ISRC fix in #16

The 2021 remaster of Smells Like Teen Spirit returns nothing from AcousticBrainz; the original returns a full analysis. On the pre-fix code, mood would have silently vanished on exactly the tracks the ISRC bug hit.

## What it deliberately does not do

**No energy.** There is no energy classifier and no free source publishes one. It could only be fabricated from loudness and onset rate, so it is omitted and the README says why.

**Genre and gender classifiers ignored.** They file Smells Like Teen Spirit as `trance` / `ChaChaCha` / `jaz`. MusicBrainz already supplies real genres with vote weights.

## The trap this was built around

Each classifier returns a `value` label and a `probability` that is **confidence in that label, not intensity**. Nirvana returns `mood_happy: "not_happy", p=0.879` - 88% confident it is *not* happy.

Storing `probability` directly would report that track as 88% happy. The client reads the positive class out of `all` instead, so the sign cannot invert, with a fallback for older submissions that omit `all` and a test named for the regression.

Verified against the live archive:

```
danceability 0.47   moodAggressive 0.949   moodHappy 0.121
moodRelaxed  0.018  moodAcoustic   0.008   instrumental 0.019
```

## Cost

One request per song, landing inside a gap the MusicBrainz throttle was already waiting out. Measured 21.7s for 8 songs, inside the two-to-three seconds per song the README already quoted. The per-row streaming contract is untouched.

## Shape

Missing data is `null`, never `0`: `0` is a real danceability score, so a filled gap would drag averages toward the floor and be indistinguishable from a genuine result. `blankRow` carries the audio fields so found and missing rows stay identical in shape, and the summary reports `audioAnalysed` / `audioMissing` following the existing `bpmMissing` precedent.

## Verification

119 tests pass, 23 new. Prettier clean. Packaged build reports 1.1.3 with `src/api/acousticbrainz.js` confirmed present in `app.asar`.